### PR TITLE
bump log dependency to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ description = "A logger that prints all messages with a readable output format"
 repository = "https://github.com/borntyping/rust-simple_logger"
 
 [dependencies]
-log = "^0.3.1"
+log = "^0.4.1"
 time = "^0.1.25"

--- a/examples/init_with_level.rs
+++ b/examples/init_with_level.rs
@@ -2,10 +2,10 @@
 extern crate log;
 extern crate simple_logger;
 
-use log::LogLevel;
+use log::Level;
 
 fn main() {
-    simple_logger::init_with_level(LogLevel::Warn).unwrap();
+    simple_logger::init_with_level(Level::Warn).unwrap();
 
     warn!("This will be logged.");
     info!("This will NOT be logged.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,29 +1,31 @@
 //! A logger that prints all messages with a readable output format.
 
-#[macro_use]
 extern crate log;
 extern crate time;
 
-use log::{Log,LogLevel,LogMetadata,LogRecord,SetLoggerError};
+use log::{Log,Level,Metadata,Record,SetLoggerError};
 
 struct SimpleLogger {
-    log_level: LogLevel,
+    level: Level,
 }
 
 impl Log for SimpleLogger {
-    fn enabled(&self, metadata: &LogMetadata) -> bool {
-        metadata.level() <= self.log_level
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= self.level
     }
 
-    fn log(&self, record: &LogRecord) {
+    fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
             println!(
                 "{} {:<5} [{}] {}",
                 time::strftime("%Y-%m-%d %H:%M:%S", &time::now()).unwrap(),
                 record.level().to_string(),
-                record.location().module_path(),
+                record.module_path().unwrap_or_default(),
                 record.args());
         }
+    }
+
+    fn flush(&self) {
     }
 }
 
@@ -35,17 +37,28 @@ impl Log for SimpleLogger {
 /// # extern crate simple_logger;
 /// #
 /// # fn main() {
-/// simple_logger::init_with_level(log::LogLevel::Warn).unwrap();
+/// simple_logger::init_with_level(log::Level::Warn).unwrap();
 ///
 /// warn!("This is an example message.");
 /// info!("This message will not be logged.");
 /// # }
 /// ```
-pub fn init_with_level(log_level: LogLevel) -> Result<(), SetLoggerError> {
-    log::set_logger(|max_log_level| {
-        max_log_level.set(log_level.to_log_level_filter());
-        return Box::new(SimpleLogger { log_level: log_level });
-    })
+pub fn init_with_level(level: Level) -> Result<(), SetLoggerError> {
+    static ERROR_LOGGER: SimpleLogger = SimpleLogger { level: Level::Error };
+    static WARN_LOGGER: SimpleLogger = SimpleLogger { level: Level::Warn };
+    static INFO_LOGGER: SimpleLogger = SimpleLogger { level: Level::Info };
+    static DEBUG_LOGGER: SimpleLogger = SimpleLogger { level: Level::Debug };
+    static TRACE_LOGGER: SimpleLogger = SimpleLogger { level: Level::Trace };
+
+    log::set_logger(match level {
+        Level::Error => &ERROR_LOGGER,
+        Level::Warn => &WARN_LOGGER,
+        Level::Info => &INFO_LOGGER,
+        Level::Debug => &DEBUG_LOGGER,
+        Level::Trace => &TRACE_LOGGER,
+    })?;
+    log::set_max_level(level.to_level_filter());
+    Ok(())
 }
 
 /// Initializes the global logger with a SimpleLogger instance with
@@ -61,5 +74,5 @@ pub fn init_with_level(log_level: LogLevel) -> Result<(), SetLoggerError> {
 /// # }
 /// ```
 pub fn init() -> Result<(), SetLoggerError> {
-    init_with_level(LogLevel::Trace)
+    init_with_level(Level::Trace)
 }


### PR DESCRIPTION
Same as https://github.com/borntyping/rust-simple_logger/pull/2 but *without* `std` dependency.