### PR TITLE
Adding optional colorized output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ authors = ["Sam Clements <sam@borntyping.co.uk>"]
 description = "A logger that prints all messages with a readable output format"
 repository = "https://github.com/borntyping/rust-simple_logger"
 
+[features]
+default = ["colored"]
+
 [dependencies]
 log = { version = "^0.4.1", features = ["std"] }
 time = "^0.1.25"
+colored = { version = "^1.6", optional = true }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ You can run the above example with:
 cargo run --example init
 ```
 
+If you want to remove the colorized output and its dependencies, add the
+the following to your Cargo.toml:
+
+```
+[dependencies.simple_logger]
+default-features = false
+```
+
 Licence
 -------
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 extern crate log;
 extern crate time;
 
+#[cfg(feature = "colored")] extern crate colored;
+#[cfg(feature = "colored")] use colored::*;
+
 use log::{Log,Level,Metadata,Record,SetLoggerError};
 
 struct SimpleLogger {
@@ -16,10 +19,24 @@ impl Log for SimpleLogger {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
+            let level_string = {
+                #[cfg(feature = "colored")] {
+                    match record.level() {
+                        Level::Error => record.level().to_string().red(),
+                        Level::Warn => record.level().to_string().yellow(),
+                        Level::Info => record.level().to_string().cyan(),
+                        Level::Debug => record.level().to_string().purple(),
+                        Level::Trace => record.level().to_string().normal(),
+                    }
+                }
+                #[cfg(not(feature = "colored"))] {
+                    record.level().to_string()
+                }
+            };
             println!(
                 "{} {:<5} [{}] {}",
                 time::strftime("%Y-%m-%d %H:%M:%S", &time::now()).unwrap(),
-                record.level().to_string(),
+                level_string,
                 record.module_path().unwrap_or_default(),
                 record.args());
         }


### PR DESCRIPTION
This pull would allow an end-user to optionally use colorized output based on the log levels.