### PR TITLE
Minor improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ impl Log for SimpleLogger {
         if self.enabled(record.metadata()) {
             println!(
                 "{} {:<5} [{}] {}",
-                Local::now().format("%Y-%m-%d %H:%M:%S"),
+                Local::now().format("%Y-%m-%d %H:%M:%S,%3f"),
                 record.level().to_string(),
                 record.module_path().unwrap_or_default(),
                 record.args());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ impl Log for SimpleLogger {
             println!(
                 "{} {:<5} [{}] {}",
                 Local::now().format("%Y-%m-%d %H:%M:%S,%3f"),
-                record.level().to_string(),
+                record.level(),
                 record.module_path().unwrap_or_default(),
                 record.args());
         }


### PR DESCRIPTION
This PR adds printing of milliseconds as [Supervisord](https://github.com/Supervisor/supervisor/blob/master/supervisor/loggers.py#L287-L289) does.

`to_string` is removed to prevent allocation of a temporary string.