### PR TITLE
respect target argument

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,11 +34,16 @@ impl Log for SimpleLogger {
                     record.level().to_string()
                 }
             };
+            let target = if record.target().len() > 0 {
+                record.target()
+            } else {
+                record.module_path().unwrap_or_default()
+            };
             println!(
                 "{} {:<5} [{}] {}",
                 Local::now().format("%Y-%m-%d %H:%M:%S,%3f"),
                 level_string,
-                record.module_path().unwrap_or_default(),
+                target,
                 record.args());
         }
     }


### PR DESCRIPTION
Currently simple_logger ignores the target argument and always defaults to the package name, which is only supposed to be the fallback in cases where a target is not provided. This change uses the target (if it's not the default value), and otherwise uses the package.