### PR TITLE
Add 'chrono' compile time option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ description = "A logger that prints all messages with a readable output format"
 repository = "https://github.com/borntyping/rust-simple_logger"
 
 [features]
-default = ["colored"]
+default = ["colored", "chrono"]
 
 [dependencies]
 log = { version = "^0.4.5", features = ["std"] }
-chrono = "0.4.6"
+chrono = { version = "0.4.6", optional = true }
 colored = { version = "^1.6", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 //! A logger that prints all messages with a readable output format.
 
 extern crate log;
-extern crate chrono;
+use log::{Log,Level,Metadata,Record,SetLoggerError};
 
 #[cfg(feature = "colored")] extern crate colored;
 #[cfg(feature = "colored")] use colored::*;
 
-use log::{Log,Level,Metadata,Record,SetLoggerError};
-use chrono::Local;
+#[cfg(feature = "chrono")] extern crate chrono;
+#[cfg(feature = "chrono")] use chrono::Local;
 
 struct SimpleLogger {
     level: Level,
@@ -39,12 +39,21 @@ impl Log for SimpleLogger {
             } else {
                 record.module_path().unwrap_or_default()
             };
-            println!(
-                "{} {:<5} [{}] {}",
-                Local::now().format("%Y-%m-%d %H:%M:%S,%3f"),
-                level_string,
-                target,
-                record.args());
+            #[cfg(feature = "chrono")] {
+                println!(
+                    "{} {:<5} [{}] {}",
+                    Local::now().format("%Y-%m-%d %H:%M:%S,%3f"),
+                    level_string,
+                    target,
+                    record.args());
+            }
+            #[cfg(not(feature = "chrono"))] {
+                println!(
+                    "{:<5} [{}] {}",
+                    level_string,
+                    target,
+                    record.args());
+            }
         }
     }
 


### PR DESCRIPTION
Disabling this feature removes the timestamp from the log output. This is
useful when the log output is sent to a logging gatherer which already does its
own timestamping (such as journald).

Addresses https://github.com/borntyping/rust-simple_logger/issues/9