### PR TITLE
Enable Windows console colors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ default = ["colored"]
 log = { version = "^0.4.5", features = ["std"] }
 chrono = "0.4.6"
 colored = { version = "^1.6", optional = true }
+
+[target.'cfg(windows)'.dependencies]
+atty = "0.2.13"
+winapi = { version = "0.3", features = ["winbase"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ colored = { version = "^1.6", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 atty = "0.2.13"
-winapi = { version = "0.3", features = ["winbase"]}
+winapi = { version = "0.3", features = ["handleapi", "winbase"]}

--- a/examples/init_with_level.rs
+++ b/examples/init_with_level.rs
@@ -10,4 +10,3 @@ fn main() {
     warn!("This will be logged.");
     info!("This will NOT be logged.");
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,17 +66,24 @@ fn set_up_color_terminal() {
     if atty::is(Stream::Stdout) {
         unsafe {
             use winapi::um::consoleapi::*;
+            use winapi::um::handleapi::*;
             use winapi::um::processenv::*;
             use winapi::um::winbase::*;
             use winapi::um::wincon::*;
 
             let stdout = GetStdHandle(STD_OUTPUT_HANDLE);
-            SetConsoleMode(
-                stdout,
-                ENABLE_PROCESSED_OUTPUT
-                    | ENABLE_WRAP_AT_EOL_OUTPUT
-                    | ENABLE_VIRTUAL_TERMINAL_PROCESSING,
-            );
+
+            if stdout == INVALID_HANDLE_VALUE {
+                return;
+            }
+
+            let mut mode: winapi::shared::minwindef::DWORD = 0;
+
+            if !GetConsoleMode(stdout, &mut mode) {
+                return;
+            }
+
+            SetConsoleMode(stdout, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,15 @@ fn set_up_color_terminal() {
             use winapi::um::consoleapi::*;
             use winapi::um::processenv::*;
             use winapi::um::winbase::*;
+            use winapi::um::wincon::*;
 
             let stdout = GetStdHandle(STD_OUTPUT_HANDLE);
-            SetConsoleMode(stdout, 0x0001 | 0x0002 | 0x0004);
+            SetConsoleMode(
+                stdout,
+                ENABLE_PROCESSED_OUTPUT
+                    | ENABLE_WRAP_AT_EOL_OUTPUT
+                    | ENABLE_VIRTUAL_TERMINAL_PROCESSING,
+            );
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ fn set_up_color_terminal() {
 
             let mut mode: winapi::shared::minwindef::DWORD = 0;
 
-            if !GetConsoleMode(stdout, &mut mode) {
+            if GetConsoleMode(stdout, &mut mode) == 0 {
                 return;
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,18 @@
 //! A logger that prints all messages with a readable output format.
 
-extern crate log;
+#[cfg(windows)]
+extern crate atty;
 extern crate chrono;
+#[cfg(feature = "colored")]
+extern crate colored;
+extern crate log;
+#[cfg(windows)]
+extern crate winapi;
 
-#[cfg(feature = "colored")] extern crate colored;
-#[cfg(feature = "colored")] use colored::*;
-
-use log::{Log,Level,Metadata,Record,SetLoggerError};
 use chrono::Local;
+#[cfg(feature = "colored")]
+use colored::*;
+use log::{Level, Log, Metadata, Record, SetLoggerError};
 
 struct SimpleLogger {
     level: Level,
@@ -21,7 +26,8 @@ impl Log for SimpleLogger {
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
             let level_string = {
-                #[cfg(feature = "colored")] {
+                #[cfg(feature = "colored")]
+                {
                     match record.level() {
                         Level::Error => record.level().to_string().red(),
                         Level::Warn => record.level().to_string().yellow(),
@@ -30,7 +36,8 @@ impl Log for SimpleLogger {
                         Level::Trace => record.level().to_string().normal(),
                     }
                 }
-                #[cfg(not(feature = "colored"))] {
+                #[cfg(not(feature = "colored"))]
+                {
                     record.level().to_string()
                 }
             };
@@ -44,12 +51,12 @@ impl Log for SimpleLogger {
                 Local::now().format("%Y-%m-%d %H:%M:%S,%3f"),
                 level_string,
                 target,
-                record.args());
+                record.args()
+            );
         }
     }
 
-    fn flush(&self) {
-    }
+    fn flush(&self) {}
 }
 
 /// Initializes the global logger with a SimpleLogger instance with
@@ -67,6 +74,21 @@ impl Log for SimpleLogger {
 /// # }
 /// ```
 pub fn init_with_level(level: Level) -> Result<(), SetLoggerError> {
+    if cfg!(windows) && cfg!(feature = "colored") {
+        use atty::Stream;
+
+        if atty::is(Stream::Stdout) {
+            unsafe {
+                use winapi::um::consoleapi::*;
+                use winapi::um::processenv::*;
+                use winapi::um::winbase::*;
+
+                let stdout = GetStdHandle(STD_OUTPUT_HANDLE);
+                SetConsoleMode(stdout, 0x0001 | 0x0002 | 0x0004);
+            }
+        }
+    }
+
     let logger = SimpleLogger { level };
     log::set_boxed_logger(Box::new(logger))?;
     log::set_max_level(level.to_level_filter());


### PR DESCRIPTION
Hello,

Thank you for your awesome library that makes it really easy to print debug messages. I would like to propose some changes that enable Windows console color output (tested with `cmd` and `PowerShell`).

Examples:
* **before**:
  * _CMD_: ![CMD](https://i.ibb.co/KW8dPBz/2019-12-23-10-42-44.png)
  * _PowerShell_: ![PowerShell](https://i.ibb.co/ckJHgq9/2019-12-23-10-43-22.png)
* **after**:
  * _CMD_: ![CMD_w_patch](https://i.ibb.co/QcFryGb/2019-12-23-10-49-52.png)
  * _PowerShell_: ![PowerShell_w_path](https://i.ibb.co/6Bn5rT9/2019-12-23-10-54-14.png)

Also, I ran `rustfmt` on `src/lib.rs` file, but may revert that changes if needed.