### PR TITLE
Migrate to github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: ci
+
+on: [pull_request, push]
+
+env:
+  # Just a reassurance to mitigate sudden network connection problems
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: full
+
+  # We don't need any debug symbols on ci, this also speeds up builds a bunch
+  RUSTFLAGS: --deny warnings -Cdebuginfo=0
+  RUSTDOCFLAGS: --deny warnings
+
+jobs:
+  rust-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt, clippy
+
+      - run: cargo clippy --workspace
+      - run: cargo fmt --all -- --check
+
+  rust-test:
+    runs-on: ${{ matrix.os }}
+
+    # We don't want unstable jobs to fail our cicd
+    continue-on-error: ${{ matrix.toolchain != 'stable' }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        toolchain: [stable]
+        include:
+          - { os: ubuntu-latest, toolchain: beta }
+          - { os: ubuntu-latest, toolchain: nightly }
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+
+      - run: cargo +${{ matrix.toolchain }} build --workspace
+      - run: cargo +${{ matrix.toolchain }} test --workspace --no-run
+      - run: cargo +${{ matrix.toolchain }} test --workspace
+
+  rust-publish-crates:
+    # Publishing goes when we create a new git tag on the repo
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    # XXX: this job must execute only if all checks pass!
+    needs:
+      - rust-lint
+      - rust-test
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - run: cargo publish --token ${{ secrets.CRATES_TOKEN }})

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: rust
-rust:
-  - stable
-  - beta
-  - nightly
-sudo: false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ impl Log for SimpleLogger {
                     record.level().to_string()
                 }
             };
-            let target = if record.target().len() > 0 {
+            let target = if !record.target().is_empty() {
                 record.target()
             } else {
                 record.module_path().unwrap_or_default()


### PR DESCRIPTION
The jobs run `clippy` and `rustfmt` checks, as well as `cargo test`.
There is also a job to publish the crate. You only need to add `CRATES_TOKEN`, which is an API token from [`crates.io`](https://crates.io) to the repo secrets.
After that, to test and publish the crate run this in the local repo on the latest checkout of `master`:
```
git tag v1.0.0
git push --tags
```