### PR TITLE
Allow to log only on specific log targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,10 @@ Usage
 -----
 
 ```rust
-#[macro_use]
-extern crate log;
-extern crate simple_logger;
-
 fn main() {
     simple_logger::init().unwrap();
 
-    warn!("This is an example message.");
+    log::warn!("This is an example message.");
 }
 ```
 

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -1,9 +1,5 @@
-#[macro_use]
-extern crate log;
-extern crate simple_logger;
-
 fn main() {
     simple_logger::init().unwrap();
 
-    warn!("This is an example message.");
+    log::warn!("This is an example message.");
 }

--- a/examples/init_with_level.rs
+++ b/examples/init_with_level.rs
@@ -1,12 +1,8 @@
-#[macro_use]
-extern crate log;
-extern crate simple_logger;
-
 use log::Level;
 
 fn main() {
     simple_logger::init_with_level(Level::Warn).unwrap();
 
-    warn!("This will be logged.");
-    info!("This will NOT be logged.");
+    log::warn!("This will be logged.");
+    log::info!("This will NOT be logged.");
 }

--- a/examples/init_with_level_and_targets.rs
+++ b/examples/init_with_level_and_targets.rs
@@ -1,0 +1,7 @@
+use log::Level;
+
+fn main() {
+    simple_logger::init_with_level_and_targets(Level::Info, &["wrong_target"]).unwrap();
+
+    log::info!("This will NOT be logged. (Wrong target)");
+}


### PR DESCRIPTION
This PR should allow to log only on specific log targets thus preventing any non-wanted spamming from dependencies.

Closes: #15