### PR TITLE
Revert deprecation of stand-alone initialisation functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,22 +262,19 @@ fn set_up_color_terminal() {
     }
 }
 
-/// See [this](struct.SimpleLogger.html#method.with_level)
-#[deprecated(since = "1.8.0", note = "Please use the Builder pattern instead.")]
+/// See [`SimpleLogger::with_level`]
 pub fn init_with_level(level: Level) -> Result<(), SetLoggerError> {
     SimpleLogger::new()
         .with_level(level.to_level_filter())
         .init()
 }
 
-/// See [this](struct.SimpleLogger.html#method.new)
-#[deprecated(since = "1.8.0", note = "Please use the Builder pattern instead.")]
+/// See [`SimpleLogger::new`]
 pub fn init() -> Result<(), SetLoggerError> {
     SimpleLogger::new().init()
 }
 
-/// See [this](struct.SimpleLogger.html#method.from_env)
-#[deprecated(since = "1.8.0", note = "Please use the Builder pattern instead.")]
+/// See [`SimpleLogger::from_env`]
 pub fn init_by_env() {
     SimpleLogger::from_env().init().unwrap()
 }


### PR DESCRIPTION
These functions provide a very pleasant shortcut in the minimalist spirit of this crate.

For more advanced usages, the builder pattern is still available.