### PR TITLE
Adding the hability to choose wich feature to enable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2018"
 
 [features]
 default = ["colored", "chrono"]
+color = ["colored"]
+ts = ["chrono"]
 
 [dependencies]
 log = { version = "^0.4.5", features = ["std"] }

--- a/README.md
+++ b/README.md
@@ -33,12 +33,28 @@ You can run the above example with:
 cargo run --example init
 ```
 
-If you want to remove the colorized output and its dependencies, add the
+If you want to remove the colorized output and the timestamps with its respective dependencies, add the
 the following to your Cargo.toml:
 
 ```
 [dependencies.simple_logger]
 default-features = false
+```
+
+Or to remove only the colorized output but keep the timestamps:
+
+```
+[dependencies.simple_logger]
+default-features = false
+features = ["ts"]
+```
+
+Or to remove only the timestamps but keep the colorized output:
+
+```
+[dependencies.simple_logger]
+default-features = false
+features = ["color"]
 ```
 
 Licence


### PR DESCRIPTION
Since https://github.com/borntyping/rust-simple_logger/pull/10 is possible to disable colorized output **and** timestamps, with this new addition it will be possible to choose disabling one while still keeping the other one.