### PR TITLE
Add semicolon which caused compilation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage
 -----
 
 ```rust
-use simple_logger::SimpleLogger
+use simple_logger::SimpleLogger;
 
 fn main() {
     SimpleLogger::new().init().unwrap();


### PR DESCRIPTION
The provided example didn't compile because of the missing semicolon. 