### PR TITLE
Add an option to control whether timestamps are to be printed or not.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,10 @@ pub struct SimpleLogger {
     /// After initialization, the vector is sorted so that the first (prefix) match
     /// directly gives us the desired log level.
     module_levels: Vec<(String, LevelFilter)>,
+    /// Whether to include timestamps or not
+    ///
+    /// If the `chrono` feature is not enabled, this will not do anything.
+    timestamps:bool
 }
 
 impl SimpleLogger {
@@ -37,6 +41,7 @@ impl SimpleLogger {
         SimpleLogger {
             default_level: LevelFilter::Trace,
             module_levels: Vec::new(),
+	    timestamps: true
         }
     }
 
@@ -143,6 +148,15 @@ impl SimpleLogger {
         self
     }
 
+    /// Control whether timestamps are printed or not.
+    ///
+    /// Timestamps will be printed by default if the `chrono` feature is enabled.
+    #[must_use = "You must call init() to begin logging"]
+    pub fn with_timestamps(mut self, timestamps: bool) -> SimpleLogger {
+        self.timestamps = timestamps;
+        self
+    }
+
     /// 'Init' the actual logger, instantiate it and configure it,
     /// this method MUST be called in order for the logger to be effective.
     pub fn init(mut self) -> Result<(), SetLoggerError> {
@@ -214,7 +228,7 @@ impl Log for SimpleLogger {
                 record.module_path().unwrap_or_default()
             };
             #[cfg(feature = "chrono")]
-            {
+            if self.timestamps {
                 println!(
                     "{} {:<5} [{}] {}",
                     Local::now().format("%Y-%m-%d %H:%M:%S,%3f"),
@@ -222,11 +236,9 @@ impl Log for SimpleLogger {
                     target,
                     record.args()
                 );
+		return;
             }
-            #[cfg(not(feature = "chrono"))]
-            {
-                println!("{:<5} [{}] {}", level_string, target, record.args());
-            }
+	    println!("{:<5} [{}] {}", level_string, target, record.args());
         }
     }
 


### PR DESCRIPTION
Timestamps are useful when debugging, but when the program is executed from systemd, journald automatically adds timestamps to the lines, so one gets duplicate timestamps.

This adds an option to turn timestamps off without having to recompile with a different feature set.
