### PR TITLE
Use a 'stderr' feature to target log output to stderr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 default = ["colored", "chrono"]
 colors = ["colored"]
 timestamps = ["chrono"]
+stderr = []
 
 [dependencies]
 log = { version = "^0.4.5", features = ["std"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,16 @@ impl Log for SimpleLogger {
 
             #[cfg(feature = "chrono")]
             if self.timestamps {
+                #[cfg(not(feature = "stderr"))]
                 println!(
+                    "{} {:<5} [{}] {}",
+                    Local::now().format("%Y-%m-%d %H:%M:%S,%3f"),
+                    level_string,
+                    target,
+                    record.args()
+                );
+                #[cfg(feature = "stderr")]
+                eprintln!(
                     "{} {:<5} [{}] {}",
                     Local::now().format("%Y-%m-%d %H:%M:%S,%3f"),
                     level_string,
@@ -315,7 +324,10 @@ impl Log for SimpleLogger {
                 return;
             }
 
+            #[cfg(not(feature = "stderr"))]
             println!("{:<5} [{}] {}", level_string, target, record.args());
+            #[cfg(feature = "stderr")]
+            eprintln!("{:<5} [{}] {}", level_string, target, record.args());
         }
     }
 


### PR DESCRIPTION
Low hanging fruit to address #21. Usually it is ok to decide at compile time where log output shall go.
