### PR TITLE
Add 'threadid' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ default = ["colored", "chrono"]
 colors = ["colored"]
 timestamps = ["chrono"]
 stderr = []
+threadid = []
 
 [dependencies]
 log = { version = "^0.4.5", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ repository = "https://github.com/borntyping/rust-simple_logger"
 edition = "2018"
 
 [features]
-default = ["colored", "chrono"]
+default = ["colored", "chrono", "thread_ids"]
 colors = ["colored"]
 timestamps = ["chrono"]
 stderr = []
-threadid = []
+thread_ids = []
 
 [dependencies]
 log = { version = "^0.4.5", features = ["std"] }

--- a/README.md
+++ b/README.md
@@ -58,12 +58,9 @@ default-features = false
 features = ["colors"]
 ```
 
-To include the name of the thread logging enable the `threadid` feature:
-
-```
-[dependencies.simple_logger]
-features = ["threadid"]
-```
+The 'thread_ids' feature lets one log the name/identifier of the thread generating
+a log message. This feature is enabled by default but the the logger won't use it
+unless enabled by the `SimpleLogger::new().with_thread_ids(true)`.
 
 To direct logging output to `stderr` use the `stderr` feature:
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ default-features = false
 features = ["colors"]
 ```
 
+To include the name of the thread logging enable the `threadid` feature:
+
+```
+[dependencies.simple_logger]
+features = ["threadid"]
+```
+
 To direct logging output to `stderr` use the `stderr` feature:
 
 ```

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -1,7 +1,7 @@
 use simple_logger::SimpleLogger;
 
 fn main() {
-    SimpleLogger::new().init().unwrap();
+    SimpleLogger::new().with_thread_ids(true).init().unwrap();
 
     std::thread::spawn(|| {
         log::warn!("Unnamed thread logs here.");

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -1,0 +1,22 @@
+use simple_logger::SimpleLogger;
+
+fn main() {
+    SimpleLogger::new().init().unwrap();
+
+    std::thread::spawn(|| {
+        log::warn!("Unnamed thread logs here.");
+    })
+    .join()
+    .unwrap();
+
+    std::thread::Builder::new()
+        .name("named_thread".to_string())
+        .spawn(|| {
+            log::warn!("Named thread logs here.");
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+
+    log::warn!("This is an example message.");
+}

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -1,7 +1,11 @@
 use simple_logger::SimpleLogger;
 
 fn main() {
+    #[cfg(feature = "thread_ids")]
     SimpleLogger::new().with_thread_ids(true).init().unwrap();
+
+    #[cfg(not(feature = "thread_ids"))]
+    SimpleLogger::new().init().unwrap();
 
     std::thread::spawn(|| {
         log::warn!("Unnamed thread logs here.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ impl SimpleLogger {
     /// Control whether messages include the thread id or not.
     ///
     /// This method is only available if the `thread_ids` feature is enabled.
-    /// Tread ids are disabled by default.
+    /// Thread ids are disabled by default.
     #[must_use = "You must call init() to begin logging"]
     #[cfg(feature = "thread_ids")]
     pub fn with_thread_ids(mut self, threadids: bool) -> SimpleLogger {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub struct SimpleLogger {
     ///
     /// This field is only available if the `thread_ids` feature is enabled.
     #[cfg(feature = "thread_ids")]
-    threadids: bool,
+    thread_ids: bool,
 }
 
 impl SimpleLogger {
@@ -93,7 +93,7 @@ impl SimpleLogger {
             colors: true,
 
             #[cfg(feature = "thread_ids")]
-            threadids: false,
+            thread_ids: false,
         }
     }
 
@@ -242,8 +242,8 @@ impl SimpleLogger {
     /// Thread ids are disabled by default.
     #[must_use = "You must call init() to begin logging"]
     #[cfg(feature = "thread_ids")]
-    pub fn with_thread_ids(mut self, threadids: bool) -> SimpleLogger {
-        self.threadids = threadids;
+    pub fn with_thread_ids(mut self, thread_ids: bool) -> SimpleLogger {
+        self.thread_ids = thread_ids;
         self
     }
 
@@ -327,7 +327,7 @@ impl Log for SimpleLogger {
             let thread_id = std::thread::current();
 
             #[cfg(feature = "thread_ids")]
-            let (target_thread, target_delimiter) = if self.threadids {
+            let (target_thread, target_delimiter) = if self.thread_ids {
                 (thread_id.name().unwrap_or("UNKNOWN"), "@")
             } else {
                 ("", "")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,8 @@ pub struct SimpleLogger {
 
     /// Whether to use thead identifiers or not.
     ///
-    /// This field is only available if the `threadid` feature is enabled.
-    #[cfg(feature = "threadid")]
+    /// This field is only available if the `thread_ids` feature is enabled.
+    #[cfg(feature = "thread_ids")]
     threadids: bool,
 }
 
@@ -92,8 +92,8 @@ impl SimpleLogger {
             #[cfg(feature = "colored")]
             colors: true,
 
-            #[cfg(feature = "threadid")]
-            threadids: true,
+            #[cfg(feature = "thread_ids")]
+            threadids: false,
         }
     }
 
@@ -238,10 +238,11 @@ impl SimpleLogger {
 
     /// Control whether messages include the thread id or not.
     ///
-    /// This method is only available if the `threadid` feature is enabled.
+    /// This method is only available if the `thread_ids` feature is enabled.
+    /// Tread ids are disabled by default.
     #[must_use = "You must call init() to begin logging"]
-    #[cfg(feature = "threadid")]
-    pub fn with_threadids(mut self, threadids: bool) -> SimpleLogger {
+    #[cfg(feature = "thread_ids")]
+    pub fn with_thread_ids(mut self, threadids: bool) -> SimpleLogger {
         self.threadids = threadids;
         self
     }
@@ -322,17 +323,17 @@ impl Log for SimpleLogger {
                 record.module_path().unwrap_or_default()
             };
 
-            #[cfg(feature = "threadid")]
+            #[cfg(feature = "thread_ids")]
             let thread_id = std::thread::current();
 
-            #[cfg(feature = "threadid")]
+            #[cfg(feature = "thread_ids")]
             let (target_thread, target_delimiter) = if self.threadids {
                 (thread_id.name().unwrap_or("UNKNOWN"), "@")
             } else {
                 ("", "")
             };
 
-            #[cfg(not(feature = "threadid"))]
+            #[cfg(not(feature = "thread_ids"))]
             let (target_thread, target_delimiter) = ("", "");
 
             #[cfg(feature = "chrono")]


### PR DESCRIPTION
When enabled then the log messages include a the threads name (if set) as '[name@target]'.

This feature is not enabled by default as it changes the logging format. The actual format is
premature and may be refined.

Threads without an name are printed as 'UNNAMED', in future versions this will be enhanced by
using the threads identifier as decimal number (still an experimental API in rust https://doc.rust-lang.org/std/thread/struct.ThreadId.html#method.as_u64 ).

Notes:

The formatting calls got 'slightly' ugly now, but should be reasonable efficient as no extra allocations happen. Eventually the compiler may even optimize the static-empty string formatting out.

The actual format (name@target) is up for discussion, I haven't come up with something better/more standard yet.
