### PR TITLE
Exchanged `chrono` Dependency for Equal Implementation Using The Still-Maintained `time` Crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,15 @@ repository = "https://github.com/borntyping/rust-simple_logger"
 edition = "2018"
 
 [features]
-default = ["colored", "chrono"]
+default = ["colored", "time"]
 colors = ["colored"]
-timestamps = ["chrono"]
+timestamps = ["time"]
 stderr = []
 
 [dependencies]
 log = { version = "^0.4.5", features = ["std"] }
-chrono = { version = "0.4.6", optional = true }
 colored = { version = "^1.6", optional = true }
+time = { version = "0.3.4", features = ["local-offset", "formatting", "macros"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
 atty = "0.2.13"
@@ -28,4 +28,4 @@ required-features = ["colored"]
 
 [[example]]
 name = "timestamps"
-required-features = ["chrono"]
+required-features = ["time"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,12 +28,16 @@
 //! simple_logger::init_with_level(log::Level::Warn).unwrap();
 //! ```
 
-#[cfg(feature = "chrono")]
-use chrono::Local;
+#[cfg(feature = "time")]
+use time::OffsetDateTime;
 #[cfg(feature = "colored")]
 use colored::*;
 use log::{Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
 use std::collections::HashMap;
+use winapi::um::wincon::ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+
+// Same as Local::now().format("%Y-%m-%d %H:%M:%S,%3f") from `chrono`
+static FORMAT: &[::time::format_description::FormatItem<'_>] = time::macros::format_description!("[year]-[month]-[day] [hour]:[minute]:[second],[subsecond digits:3]");
 
 /// Implements [`Log`] and a set of simple builder methods for configuration.
 ///
@@ -52,8 +56,8 @@ pub struct SimpleLogger {
 
     /// Whether to include timestamps or not
     ///
-    /// This field is only available if the `chrono` feature is enabled.
-    #[cfg(feature = "chrono")]
+    /// This field is only available if the `time` feature is enabled.
+    #[cfg(feature = "time")]
     timestamps: bool,
 
     /// Whether to use color output or not.
@@ -80,7 +84,7 @@ impl SimpleLogger {
             default_level: LevelFilter::Trace,
             module_levels: Vec::new(),
 
-            #[cfg(feature = "chrono")]
+            #[cfg(feature = "time")]
             timestamps: true,
 
             #[cfg(feature = "colored")]
@@ -209,9 +213,9 @@ impl SimpleLogger {
 
     /// Control whether timestamps are printed or not.
     ///
-    /// This method is only available if the `chrono` feature is enabled.
+    /// This method is only available if the `time` feature is enabled.
     #[must_use = "You must call init() to begin logging"]
-    #[cfg(feature = "chrono")]
+    #[cfg(feature = "time")]
     pub fn with_timestamps(mut self, timestamps: bool) -> SimpleLogger {
         self.timestamps = timestamps;
         self
@@ -303,12 +307,12 @@ impl Log for SimpleLogger {
                 record.module_path().unwrap_or_default()
             };
 
-            #[cfg(feature = "chrono")]
+            #[cfg(feature = "time")]
             if self.timestamps {
                 #[cfg(not(feature = "stderr"))]
                 println!(
                     "{} {:<5} [{}] {}",
-                    Local::now().format("%Y-%m-%d %H:%M:%S,%3f"),
+                    OffsetDateTime::now_local().unwrap().format(&FORMAT).unwrap(),
                     level_string,
                     target,
                     record.args()
@@ -316,7 +320,7 @@ impl Log for SimpleLogger {
                 #[cfg(feature = "stderr")]
                 eprintln!(
                     "{} {:<5} [{}] {}",
-                    Local::now().format("%Y-%m-%d %H:%M:%S,%3f"),
+                    OffsetDateTime::now_local().unwrap().format(&FORMAT).unwrap(),
                     level_string,
                     target,
                     record.args()
@@ -436,7 +440,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "chrono")]
+    #[cfg(feature = "time")]
     fn test_with_timestamps() {
         let mut builder = SimpleLogger::new();
         assert!(builder.timestamps == true);


### PR DESCRIPTION
The reason for this pull request is the recent security advisory, [RUSTSEC-2020-0159](https://rustsec.org/advisories/RUSTSEC-2020-0159). This issue detected a potential segfault in `localtime_r` invocations, and given the `chrono` crate's lack of maintenance, the `time` crate, which fixed the issue, is now the preferred crate for datetime offsets and formatting.

The format used is still identical to the one achieved via `chrono`, but this implementation also prevents the issues caused by RUSTSEC-2020-0159, which were failing CI/CL actions in many repositories dependent upon `rust-simple_logger`.

The changes should still work in a no_alloc, no_std situation as expected.

(note: yes I see that I did a typo and put RUSTSEC-2021 instead of RUSTSEC-2020 in the commit. oops)