### PR TITLE
Try to fix accidentally disabled default timestamps feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/borntyping/rust-simple_logger"
 edition = "2018"
 
 [features]
-default = ["colored", "time"]
+default = ["colored", "timestamps"]
 colors = ["colored"]
 threads = []
 timestamps = ["time"]


### PR DESCRIPTION
Hi!
I have noticed that after commits, which replaces `chrono` dependency with `time`, logger does not print timestamps by default.

In this https://github.com/borntyping/rust-simple_logger/blob/main/src/lib.rs#L37 line, `chrono` feature-gate was used before dependency changes. Now it is `timestamps`.
 
So I just try to actualize default feature gates in project manifest.