### PR TITLE
Add a timestamps_utc configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple_logger"
-version = "1.15.1"
+version = "1.15.2"
 license = "MIT"
 authors = ["Sam Clements <sam@borntyping.co.uk>"]
 description = "A logger that prints all messages with a readable output format"
@@ -12,6 +12,7 @@ default = ["colors", "timestamps"]
 colors = ["colored"]
 threads = []
 timestamps = ["time"]
+timestamps_utc = ["time"]
 nightly = []
 stderr = []
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ default-features = false
 features = ["timestamps"]
 ```
 
+To include the `timestamps_utc` feature, but not the `colors` feature:
+
+```
+[dependencies.simple_logger]
+default-features = false
+features = ["timestamps_utc"]
+```
+
 To include the `colors` feature, but not the `timestamps` feature:
 
 ```


### PR DESCRIPTION
Display timestamps in utc instead of local time.

This is a workaround of #44. As OffsetDateTime::now_utc() is safe, it can be used in non single-threaded program.