### PR TITLE
Add options to use UTC timestamps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
   rust-test:
     runs-on: ${{ matrix.os }}
 
-    continue-on-error: ${{ matrix.toolchain != 'stable' || (matrix.os == 'macos-latest' && contains(matrix.features, 'timestamps')) }}
+    continue-on-error: ${{ matrix.toolchain != 'stable' }}
 
     strategy:
       matrix:
@@ -47,17 +47,17 @@ jobs:
           - "threads"
           - "timestamps"
           - "stderr"
+        exclude:
+          - os: macos-latest
+            toolchain: stable
+            features: "timestamps"
         include:
-          - {
-              os: ubuntu-latest,
-              toolchain: beta,
-              features: "colors,threads,timestamps",
-            }
-          - {
-              os: ubuntu-latest,
-              toolchain: nightly,
-              features: "colors,threads,timestamps,nightly",
-            }
+          - os: ubuntu-latest
+            toolchain: beta
+            features: "colors,threads,timestamps"
+          - os: ubuntu-latest
+            toolchain: nightly
+            features: "colors,threads,timestamps,nightly"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,11 @@
 ---
 name: ci
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 env:
   # Just a reassurance to mitigate sudden network connection problems

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple_logger"
-version = "1.15.1"
+version = "1.16.0"
 license = "MIT"
 authors = ["Sam Clements <sam@borntyping.co.uk>"]
 description = "A logger that prints all messages with a readable output format"
@@ -33,5 +33,9 @@ name = "threads"
 required-features = ["threads"]
 
 [[example]]
-name = "timestamps"
+name = "timestamps_utc"
+required-features = ["timestamps"]
+
+[[example]]
+name = "timestamps_local"
 required-features = ["timestamps"]

--- a/examples/timestamps_local.rs
+++ b/examples/timestamps_local.rs
@@ -1,7 +1,7 @@
 use simple_logger::SimpleLogger;
 
 fn main() {
-    SimpleLogger::new().with_timestamps(true).init().unwrap();
+    SimpleLogger::new().with_utc_timestamps(true).init().unwrap();
 
     log::warn!("This is an example message.");
 }

--- a/examples/timestamps_local.rs
+++ b/examples/timestamps_local.rs
@@ -1,7 +1,7 @@
 use simple_logger::SimpleLogger;
 
 fn main() {
-    SimpleLogger::new().with_utc_timestamps(true).init().unwrap();
+    SimpleLogger::new().with_local_timestamps().init().unwrap();
 
     log::warn!("This is an example message.");
 }

--- a/examples/timestamps_utc.rs
+++ b/examples/timestamps_utc.rs
@@ -1,0 +1,7 @@
+use simple_logger::SimpleLogger;
+
+fn main() {
+    SimpleLogger::new().with_utc_timestamps(true).init().unwrap();
+
+    log::warn!("This is an example message.");
+}

--- a/examples/timestamps_utc.rs
+++ b/examples/timestamps_utc.rs
@@ -1,7 +1,7 @@
 use simple_logger::SimpleLogger;
 
 fn main() {
-    SimpleLogger::new().with_utc_timestamps(true).init().unwrap();
+    SimpleLogger::new().with_utc_timestamps().init().unwrap();
 
     log::warn!("This is an example message.");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,7 +414,7 @@ impl Log for SimpleLogger {
                             "behaviour. See the time crate's documentation for more information. ",
                             "(https://time-rs.github.io/internal-api/time/index.html#feature-flags)"
                         )).format(&TIMESTAMP_FORMAT).unwrap()),
-                    Timestamps::Utc => format!("{} ", OffsetDateTime::now_utc()),
+                    Timestamps::Utc => format!("{} ", OffsetDateTime::now_utc().format(&TIMESTAMP_FORMAT).unwrap()),
                 }
 
                 #[cfg(not(feature = "timestamps"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,14 @@ const TIMESTAMP_FORMAT: &[FormatItem] = time::macros::format_description!(
     "[year]-[month]-[day] [hour]:[minute]:[second],[subsecond digits:3]"
 );
 
+#[cfg(feature = "timestamps")]
+#[derive(PartialEq)]
+enum Timestamps {
+    None,
+    Local,
+    UTC
+}
+
 /// Implements [`Log`] and a set of simple builder methods for configuration.
 ///
 /// Use the various "builder" methods on this struct to configure the logger,
@@ -63,17 +71,11 @@ pub struct SimpleLogger {
     #[cfg(feature = "threads")]
     threads: bool,
 
-    /// Whether to include timestamps or not
+    /// Control how timestamps are displayed.
     ///
     /// This field is only available if the `timestamps` feature is enabled.
     #[cfg(feature = "timestamps")]
-    timestamps: bool,
-
-    /// Whether to show timestamps in UTC time (true) or local time (false)
-    ///
-    /// This field is only available if the `timestamps` feature is enabled.
-    #[cfg(feature = "timestamps")]
-    timestamps_utc: bool,
+    timestamps: Timestamps,
 
     /// Whether to use color output or not.
     ///
@@ -103,10 +105,7 @@ impl SimpleLogger {
             threads: false,
 
             #[cfg(feature = "timestamps")]
-            timestamps: true,
-
-            #[cfg(feature = "timestamps")]
-            timestamps_utc: false,
+            timestamps: Timestamps::Local,
 
             #[cfg(feature = "colored")]
             colors: true,
@@ -255,34 +254,41 @@ impl SimpleLogger {
         note = "Use [`with_local_timestamps`] or [`with_utc_timestamps`] instead. Will be removed in version 2.0.0."
     )]
     pub fn with_timestamps(mut self, timestamps: bool) -> SimpleLogger {
-        self.timestamps = timestamps;
-        self.timestamps_utc = false;
+        if timestamps {
+            self.timestamps = Timestamps::Local
+        } else {
+            self.timestamps = Timestamps::None
+        }
         self
     }
 
-    /// Control whether timestamps are printed or not.
-    ///
-    /// Timestamps will be displayed in the local timezone.
+    /// Don't display any timestamps.
     ///
     /// This method is only available if the `timestamps` feature is enabled.
     #[must_use = "You must call init() to begin logging"]
     #[cfg(feature = "timestamps")]
-    pub fn with_local_timestamps(mut self, timestamps: bool) -> SimpleLogger {
-        self.timestamps = timestamps;
-        self.timestamps_utc = false;
+    pub fn without_timestamps(mut self) -> SimpleLogger {
+        self.timestamps = Timestamps::None;
         self
     }
 
-    /// Control whether timestamps are printed or not.
-    ///
-    /// Timestamps will be displayed in UTC.
+    /// Display timestamps using the local timezone.
     ///
     /// This method is only available if the `timestamps` feature is enabled.
     #[must_use = "You must call init() to begin logging"]
     #[cfg(feature = "timestamps")]
-    pub fn with_utc_timestamps(mut self, timestamps: bool) -> SimpleLogger {
-        self.timestamps = timestamps;
-        self.timestamps_utc = true;
+    pub fn with_local_timestamps(mut self) -> SimpleLogger {
+        self.timestamps = Timestamps::Local;
+        self
+    }
+
+    /// Display timestamps using UTC.
+    ///
+    /// This method is only available if the `timestamps` feature is enabled.
+    #[must_use = "You must call init() to begin logging"]
+    #[cfg(feature = "timestamps")]
+    pub fn with_utc_timestamps(mut self) -> SimpleLogger {
+        self.timestamps = Timestamps::UTC;
         self
     }
 
@@ -398,21 +404,17 @@ impl Log for SimpleLogger {
 
             let timestamp = {
                 #[cfg(feature = "timestamps")]
-                if self.timestamps {
-                    if self.timestamps_utc {
-                        format!("{} ", OffsetDateTime::now_utc())
-                    } else {
-                        format!("{} ", OffsetDateTime::now_local().expect(concat!(
+                match self.timestamps {
+                    Timestamps::None => "".to_string(),
+                    Timestamps::Local => format!("{} ", OffsetDateTime::now_local().expect(concat!(
                             "Could not determine the UTC offset on this system. ",
                             "Possible causes are that the time crate does not implement \"local_offset_at\" ",
                             "on your system, or that you are running in a multi-threaded environment and ",
                             "the time crate is returning \"None\" from \"local_offset_at\" to avoid unsafe ",
                             "behaviour. See the time crate's documentation for more information. ",
                             "(https://time-rs.github.io/internal-api/time/index.html#feature-flags)"
-                        )).format(&TIMESTAMP_FORMAT).unwrap())
-                    }
-                } else {
-                    "".to_string()
+                        )).format(&TIMESTAMP_FORMAT).unwrap()),
+                    Timestamps::UTC => format!("{} ", OffsetDateTime::now_utc()),
                 }
 
                 #[cfg(not(feature = "timestamps"))]
@@ -544,8 +546,7 @@ mod test {
     #[cfg(feature = "timestamps")]
     fn test_timestamps_defaults() {
         let builder = SimpleLogger::new();
-        assert!(builder.timestamps == true);
-        assert!(builder.timestamps_utc == false);
+        assert!(builder.timestamps == Timestamps::Local);
     }
 
     #[test]
@@ -553,24 +554,21 @@ mod test {
     #[allow(deprecated)]
     fn test_with_timestamps() {
         let builder = SimpleLogger::new().with_timestamps(false);
-        assert!(builder.timestamps == false);
-        assert!(builder.timestamps_utc == false);
+        assert!(builder.timestamps == Timestamps::None);
     }
 
     #[test]
     #[cfg(feature = "timestamps")]
     fn test_with_utc_timestamps() {
-        let builder = SimpleLogger::new().with_utc_timestamps(true);
-        assert!(builder.timestamps == true);
-        assert!(builder.timestamps_utc == true);
+        let builder = SimpleLogger::new().with_utc_timestamps();
+        assert!(builder.timestamps == Timestamps::UTC);
     }
 
     #[test]
     #[cfg(feature = "timestamps")]
     fn test_with_local_timestamps() {
-        let builder = SimpleLogger::new().with_local_timestamps(true);
-        assert!(builder.timestamps == true);
-        assert!(builder.timestamps_utc == false);
+        let builder = SimpleLogger::new().with_local_timestamps();
+        assert!(builder.timestamps == Timestamps::Local);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,12 @@ pub struct SimpleLogger {
     #[cfg(feature = "timestamps")]
     timestamps: bool,
 
+    /// Whether to show timestamps in UTC time (true) or local time (false)
+    ///
+    /// This field is only available if the `timestamps` feature is enabled.
+    #[cfg(feature = "timestamps")]
+    timestamps_utc: bool,
+
     /// Whether to use color output or not.
     ///
     /// This field is only available if the `color` feature is enabled.
@@ -98,6 +104,9 @@ impl SimpleLogger {
 
             #[cfg(feature = "timestamps")]
             timestamps: true,
+
+            #[cfg(feature = "timestamps")]
+            timestamps_utc: false,
 
             #[cfg(feature = "colored")]
             colors: true,
@@ -236,11 +245,44 @@ impl SimpleLogger {
 
     /// Control whether timestamps are printed or not.
     ///
+    /// Timestamps will be displayed in the local timezone.
+    ///
     /// This method is only available if the `timestamps` feature is enabled.
     #[must_use = "You must call init() to begin logging"]
     #[cfg(feature = "timestamps")]
+    #[deprecated(
+        since = "1.16.0",
+        note = "Use [`with_local_timestamps`] or [`with_utc_timestamps`] instead. Will be removed in version 2.0.0."
+    )]
     pub fn with_timestamps(mut self, timestamps: bool) -> SimpleLogger {
         self.timestamps = timestamps;
+        self.timestamps_utc = false;
+        self
+    }
+
+    /// Control whether timestamps are printed or not.
+    ///
+    /// Timestamps will be displayed in the local timezone.
+    ///
+    /// This method is only available if the `timestamps` feature is enabled.
+    #[must_use = "You must call init() to begin logging"]
+    #[cfg(feature = "timestamps")]
+    pub fn with_local_timestamps(mut self, timestamps: bool) -> SimpleLogger {
+        self.timestamps = timestamps;
+        self.timestamps_utc = false;
+        self
+    }
+
+    /// Control whether timestamps are printed or not.
+    ///
+    /// Timestamps will be displayed in UTC.
+    ///
+    /// This method is only available if the `timestamps` feature is enabled.
+    #[must_use = "You must call init() to begin logging"]
+    #[cfg(feature = "timestamps")]
+    pub fn with_utc_timestamps(mut self, timestamps: bool) -> SimpleLogger {
+        self.timestamps = timestamps;
+        self.timestamps_utc = true;
         self
     }
 
@@ -357,14 +399,18 @@ impl Log for SimpleLogger {
             let timestamp = {
                 #[cfg(feature = "timestamps")]
                 if self.timestamps {
-                    format!("{} ", OffsetDateTime::now_local().expect(concat!(
-                        "Could not determine the UTC offset on this system. ",
-                        "Possible causes are that the time crate does not implement \"local_offset_at\" ",
-                        "on your system, or that you are running in a multi-threaded environment and ",
-                        "the time crate is returning \"None\" from \"local_offset_at\" to avoid unsafe ",
-                        "behaviour. See the time crate's documentation for more information. ",
-                        "(https://time-rs.github.io/internal-api/time/index.html#feature-flags)"
-                    )).format(&TIMESTAMP_FORMAT).unwrap())
+                    if self.timestamps_utc {
+                        format!("{} ", OffsetDateTime::now_utc())
+                    } else {
+                        format!("{} ", OffsetDateTime::now_local().expect(concat!(
+                            "Could not determine the UTC offset on this system. ",
+                            "Possible causes are that the time crate does not implement \"local_offset_at\" ",
+                            "on your system, or that you are running in a multi-threaded environment and ",
+                            "the time crate is returning \"None\" from \"local_offset_at\" to avoid unsafe ",
+                            "behaviour. See the time crate's documentation for more information. ",
+                            "(https://time-rs.github.io/internal-api/time/index.html#feature-flags)"
+                        )).format(&TIMESTAMP_FORMAT).unwrap())
+                    }
                 } else {
                     "".to_string()
                 }
@@ -496,12 +542,35 @@ mod test {
 
     #[test]
     #[cfg(feature = "timestamps")]
-    fn test_with_timestamps() {
-        let mut builder = SimpleLogger::new();
+    fn test_timestamps_defaults() {
+        let builder = SimpleLogger::new();
         assert!(builder.timestamps == true);
+        assert!(builder.timestamps_utc == false);
+    }
 
-        builder = builder.with_timestamps(false);
+    #[test]
+    #[cfg(feature = "timestamps")]
+    #[allow(deprecated)]
+    fn test_with_timestamps() {
+        let builder = SimpleLogger::new().with_timestamps(false);
         assert!(builder.timestamps == false);
+        assert!(builder.timestamps_utc == false);
+    }
+
+    #[test]
+    #[cfg(feature = "timestamps")]
+    fn test_with_utc_timestamps() {
+        let builder = SimpleLogger::new().with_utc_timestamps(true);
+        assert!(builder.timestamps == true);
+        assert!(builder.timestamps_utc == true);
+    }
+
+    #[test]
+    #[cfg(feature = "timestamps")]
+    fn test_with_local_timestamps() {
+        let builder = SimpleLogger::new().with_local_timestamps(true);
+        assert!(builder.timestamps == true);
+        assert!(builder.timestamps_utc == false);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ const TIMESTAMP_FORMAT: &[FormatItem] = time::macros::format_description!(
 enum Timestamps {
     None,
     Local,
-    UTC
+    Utc,
 }
 
 /// Implements [`Log`] and a set of simple builder methods for configuration.
@@ -288,7 +288,7 @@ impl SimpleLogger {
     #[must_use = "You must call init() to begin logging"]
     #[cfg(feature = "timestamps")]
     pub fn with_utc_timestamps(mut self) -> SimpleLogger {
-        self.timestamps = Timestamps::UTC;
+        self.timestamps = Timestamps::Utc;
         self
     }
 
@@ -414,7 +414,7 @@ impl Log for SimpleLogger {
                             "behaviour. See the time crate's documentation for more information. ",
                             "(https://time-rs.github.io/internal-api/time/index.html#feature-flags)"
                         )).format(&TIMESTAMP_FORMAT).unwrap()),
-                    Timestamps::UTC => format!("{} ", OffsetDateTime::now_utc()),
+                    Timestamps::Utc => format!("{} ", OffsetDateTime::now_utc()),
                 }
 
                 #[cfg(not(feature = "timestamps"))]
@@ -561,7 +561,7 @@ mod test {
     #[cfg(feature = "timestamps")]
     fn test_with_utc_timestamps() {
         let builder = SimpleLogger::new().with_utc_timestamps();
-        assert!(builder.timestamps == Timestamps::UTC);
+        assert!(builder.timestamps == Timestamps::Utc);
     }
 
     #[test]


### PR DESCRIPTION
This sidesteps issues users are having when using local times in
conditions where the `time` crate cannot safely get the local time.

Thanks to @uggla and @rye.