### PR TITLE
upgrade to colored 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ stderr = []
 [dependencies]
 log = { version = "^0.4.5", features = ["std"] }
 time = { version = "0.3.5", features = ["formatting", "local-offset", "macros"], optional = true }
-colored = { version = "^1.6", optional = true }
+colored = { version = "2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 atty = "0.2.13"


### PR DESCRIPTION
The 2.0 release of colored has only a minor API change that doesn't
affect its usage in this crate:
https://github.com/mackwic/colored/blob/v2.0.0/CHANGELOG.md