### PR TITLE
Adopt windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ colored = { version = "2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 atty = "0.2.13"
-winapi = { version = "0.3", features = ["handleapi", "winbase"]}
+windows-sys = { version = "0.42.0", features = ["Win32_System_Console", "Win32_Foundation"] }
 
 [[example]]
 name = "colors"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,11 +468,11 @@ fn set_up_color_terminal() {
 
     if atty::is(Stream::Stdout) {
         unsafe {
-            use winapi::um::consoleapi::*;
-            use winapi::um::handleapi::*;
-            use winapi::um::processenv::*;
-            use winapi::um::winbase::*;
-            use winapi::um::wincon::*;
+            use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+            use windows_sys::Win32::System::Console::{
+                GetConsoleMode, GetStdHandle, SetConsoleMode, CONSOLE_MODE,
+                ENABLE_VIRTUAL_TERMINAL_PROCESSING, STD_OUTPUT_HANDLE,
+            };
 
             let stdout = GetStdHandle(STD_OUTPUT_HANDLE);
 
@@ -480,7 +480,7 @@ fn set_up_color_terminal() {
                 return;
             }
 
-            let mut mode: winapi::shared::minwindef::DWORD = 0;
+            let mut mode: CONSOLE_MODE = 0;
 
             if GetConsoleMode(stdout, &mut mode) == 0 {
                 return;


### PR DESCRIPTION
On Windows, since winapi [winapi](https://github.com/retep998/winapi-rs) is not maintained anymore and microsfot has an official api for internal links, I think it's a good idea to switch to this api [Windows API](https://docs.microsoft.com/en-us/windows/).

What do you think about it ?