### PR TITLE
Ensure log levels are appropriately padded even on coloured outputs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,19 +375,18 @@ impl Log for SimpleLogger {
                 {
                     if self.colors {
                         match record.level() {
-                            Level::Error => record.level().to_string().red().to_string(),
-                            Level::Warn => record.level().to_string().yellow().to_string(),
-                            Level::Info => record.level().to_string().cyan().to_string(),
-                            Level::Debug => record.level().to_string().purple().to_string(),
-                            Level::Trace => record.level().to_string().normal().to_string(),
-                        }
+                            Level::Error => format!("{:<5}",record.level().to_string()).red().to_string(),
+                            Level::Warn  => format!("{:<5}",record.level().to_string()).yellow().to_string(),
+                            Level::Info  => format!("{:<5}",record.level().to_string()).cyan().to_string(),
+                            Level::Debug => format!("{:<5}",record.level().to_string()).purple().to_string(),
+                            Level::Trace => format!("{:<5}",record.level().to_string()).normal().to_string(),                        }
                     } else {
-                        record.level().to_string()
+                        format!("{:<5}", record.level().to_string())
                     }
                 }
                 #[cfg(not(feature = "colored"))]
                 {
-                    record.level().to_string()
+                    format!("{:<5}", record.level().to_string())
                 }
             };
 
@@ -443,7 +442,7 @@ impl Log for SimpleLogger {
             };
 
             let message = format!(
-                "{}{:<5} [{}{}] {}",
+                "{}{} [{}{}] {}",
                 timestamp,
                 level_string,
                 target,


### PR DESCRIPTION
Hi,

First of all thanks for the library.

There was an issue when having colored output on Linux(Manjaro Linux with KDE to be specific), where coloured outputs had mis-padded logging

![image](https://user-images.githubusercontent.com/24320659/194759222-dec040f8-924a-4ef6-a021-2f28e61ca1e4.png)


The issue came about with how coloring is done on Linux, i.e we add special characters in the command line, e.g printing color red would add `\033[39m`,

Later on, when you tried to format the message with appropriate padding, for log levels

```rust
            let message = format!(
                "{}{:<5} [{}{}] {}",
                timestamp,
                level_string,
                target,...);
```

The colored log levels would not be padded because the string is  longer than 5 characters, hence the misalignment above.

The fix was to simply do the padding before the coloring which fixes that misalignment,
now with this pr the printed output looks like

![image](https://user-images.githubusercontent.com/24320659/194759536-83663703-982e-4962-a239-17e2a5209fd5.png)

This is now in tandem with the no color output which would print with the appropriate padding

Hope it helps.
