### PR TITLE
replace dependency to atty for windows targets by std implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ time = { version = "^0.3.16", features = ["formatting", "local-offset", "macros"
 colored = { version = "2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-atty = "^0.2.14"
 windows-sys = { version = "^0.42.0", features = ["Win32_System_Console", "Win32_Foundation"] }
 
 [[example]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,9 +490,9 @@ impl Log for SimpleLogger {
 
 #[cfg(all(windows, feature = "colored"))]
 fn set_up_color_terminal() {
-    use atty::Stream;
+    use std::io::{stdout, IsTerminal};
 
-    if atty::is(Stream::Stdout) {
+    if stdout().is_terminal() {
         unsafe {
             use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
             use windows_sys::Win32::System::Console::{


### PR DESCRIPTION
I replaced the use of atty by the just introduced [IsTerminal](https://doc.rust-lang.org/std/io/trait.IsTerminal.html) in std Rust.

The downside is, that this bumps MSRV to 1.70.0 but only for Windows targets which use the colored feature.
But for people who do not need or want to use the colored feature of simple_logger, this would completely remove the dependency on atty which is not maintained any more as mentioned e.g. in #74 