### PR TITLE
Upgrade windows-sys from 0.42 to 0.48

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ time = { version = "^0.3.16", features = ["formatting", "local-offset", "macros"
 colored = { version = "2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "^0.42.0", features = ["Win32_System_Console", "Win32_Foundation"] }
+windows-sys = { version = "^0.48.0", features = ["Win32_System_Console", "Win32_Foundation"] }
 
 [[example]]
 name = "colors"


### PR DESCRIPTION
Other crates are now depending on 0.48, which is not semver compatible with 0.42, resulting in cargo deny warnings.

Upgrade to the latest version of windows-sys.