### PR TITLE
add configure method, to enable users to own a valid configured instance before calling `set_boxed_logger`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,27 @@ Multiple features can be combined.
 features = ["colors", "threads", "timestamps", "nightly", "stderr"]
 ```
 
+Wrapping with another logger
+----------------------------
+
+Users that might want to wrap this logger to be able to catch log events for various 
+reasons can setup the logger as follows:
+
+On windows machines:
+```rust
+let logger = SimpleLogger::new();
+set_up_color_terminal();
+let max_level = logger.max_level(); 
+```
+
+Otherwise:
+```rust
+let logger = SimpleLogger::new();
+let max_level = logger.max_level();
+```
+
+The user can then themselves call `log::set_max_level` and `log::set_boxed_logger` or equivalent as they wish.
+
 Licence
 -------
 


### PR DESCRIPTION
My personal use case is to wrap this logger in my own logger implementation, to be able to catch log calls during testing and react to them. This PR proposes to add a `configure` method to enable users to have a completely configured instance of `SimpleLogger`. Then they can set as global logger something else that might be a wrapper around `SimpleLogger`.

Usage is simply to call `configure` instead of `init` to finish configuration of an instance of `SimpleLogger`. To avoid code duplication, `init` will internally call `configure` before `set_boxed_logger`. This means that using the chain `simpleLogger::new().configure().init()` has bad performance and would not be advised. A user would either use `configure` or `init`.

Another implentation would be to add a boolean argument to `init`, but I didn't want to change usual behavior/usage.

If this is not interesting, please ignore/close this PR, I'll continue using my fork