### PR TITLE
Add `source_location` feature to print source filename and line number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ stderr = []
 [dependencies]
 log = { version = "^0.4.17", features = ["std"] }
 time = { version = "^0.3.16", features = ["formatting", "local-offset", "macros"], optional = true }
-colored = { version = "2", optional = true }
+colored = { version = "3", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "^0.48.0", features = ["Win32_System_Console", "Win32_Foundation"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 default = ["colors", "timestamps"]
 colors = ["colored"]
 threads = []
+source_location = []
 timestamps = ["time"]
 nightly = []
 stderr = []
@@ -34,6 +35,10 @@ required-features = ["colors", "stderr"]
 [[example]]
 name = "threads"
 required-features = ["threads"]
+
+[[example]]
+name = "source_location"
+required-features = ["source_location"]
 
 [[example]]
 name = "timestamps_local"

--- a/examples/source_location.rs
+++ b/examples/source_location.rs
@@ -1,0 +1,7 @@
+use simple_logger::SimpleLogger;
+
+fn main() {
+    SimpleLogger::new().with_source_location(true).init().unwrap();
+
+    log::warn!("This is an example message.");
+}


### PR DESCRIPTION
When `source_location` feature is turn on and `.with_source_location(true)` is set, logger will print filename and line number.

And I also add the example, just run
``` bash
cargo run --example source_location --features source_location
```
You will see
``` text
2025-05-30T16:48:04.974Z WARN  [simple_logger/examples/source_location.rs:6 source_location] This is an example message.
```
close https://github.com/borntyping/rust-simple_logger/issues/76