### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ stderr = []
 
 [dependencies]
 log = { version = "^0.4.28", features = ["std"] }
-time = { version = "^0.3.44", features = ["formatting", "local-offset", "macros"], optional = true }
+time = { version = "^0.3.47", features = ["formatting", "local-offset", "macros"], optional = true }
 colored = { version = "^3.0.0", optional = true }
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
Bumps the dependency to at least 0.3.47 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2026-0009.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)